### PR TITLE
Add scroll reactive extensions.

### DIFF
--- a/RxPagingKit/PagingContentViewController+Rx.swift
+++ b/RxPagingKit/PagingContentViewController+Rx.swift
@@ -103,6 +103,12 @@ public extension Reactive where Base: PagingContentViewController {
         return delegate.willFinishPaging
     }
     
+    public func scroll(animated: Bool) -> Binder<Int> {
+        return Binder(self.base) { (controller, index) in
+            controller.scroll(to: index, animated: animated)
+        }
+    }
+    
     private var delegate: RxPagingContentViewControllerDelegateProxy {
         return RxPagingContentViewControllerDelegateProxy.proxy(for: base)
     }

--- a/RxPagingKit/PagingMenuViewController+Rx.swift
+++ b/RxPagingKit/PagingMenuViewController+Rx.swift
@@ -103,10 +103,14 @@ public extension Reactive where Base: PagingMenuViewController {
         return delegate.willDisplayCell
     }
     
+    public var scroll: Binder<Int> {
+        return Binder(self.base) { (controller, index) in
+            controller.scroll(index: index)
+        }
+    }
+    
     private var delegate: RxPagingMenuViewControllerDelegateProxy {
         return RxPagingMenuViewControllerDelegateProxy.proxy(for: base)
     }
+    
 }
-
-
-


### PR DESCRIPTION
I have created some reactive extensions for scrolling the menu or the content view controller using a bind method:

```Swift
viewModel.contentIndex.bind(to: contentViewController.rx.scroll(animated: true).disposed(by: disposeBag)
```